### PR TITLE
Avoid keyword errors

### DIFF
--- a/analyzer/src/main/java/com/novoda/sqlite/StringUtil.java
+++ b/analyzer/src/main/java/com/novoda/sqlite/StringUtil.java
@@ -26,7 +26,7 @@ public class StringUtil {
 
     private static String capitalize(String string) {
         if (string.length() > 1) {
-            return string.substring(0, 1).toUpperCase() + string.substring(1);
+            return string.substring(0, 1).toUpperCase() + string.substring(1).toLowerCase();
         }
         return "";
     }

--- a/analyzer/src/main/java/com/novoda/sqlite/StringUtil.java
+++ b/analyzer/src/main/java/com/novoda/sqlite/StringUtil.java
@@ -1,5 +1,6 @@
 package com.novoda.sqlite;
 
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -26,7 +27,7 @@ public class StringUtil {
 
     private static String capitalize(String string) {
         if (string.length() > 1) {
-            return string.substring(0, 1).toUpperCase() + string.substring(1).toLowerCase();
+            return string.substring(0, 1).toUpperCase(Locale.US) + string.substring(1).toLowerCase(Locale.US);
         }
         return "";
     }

--- a/analyzer/src/main/java/com/novoda/sqlite/model/Column.java
+++ b/analyzer/src/main/java/com/novoda/sqlite/model/Column.java
@@ -46,7 +46,7 @@ public final class Column {
     }
 
     public boolean isBoolean() {
-        return affinity == DataAffinity.NUMERIC && type.toLowerCase().contains("bool");
+        return affinity == DataAffinity.NUMERIC && type.toLowerCase(Locale.US).contains("bool");
     }
 
 

--- a/analyzer/src/main/java/com/novoda/sqlite/model/Column.java
+++ b/analyzer/src/main/java/com/novoda/sqlite/model/Column.java
@@ -2,6 +2,8 @@ package com.novoda.sqlite.model;
 
 import com.novoda.sqlite.StringUtil;
 
+import java.util.Locale;
+
 public final class Column {
     private final String name;
     private final String type;
@@ -28,7 +30,7 @@ public final class Column {
         if (camel.length() <= 1) {
             return "_" + camel;
         }
-        return "_" + camel.substring(0, 1).toLowerCase() + camel.substring(1);
+        return "_" + camel.substring(0, 1).toLowerCase(Locale.US) + camel.substring(1);
     }
 
     public String getType() {

--- a/analyzer/src/main/java/com/novoda/sqlite/model/Column.java
+++ b/analyzer/src/main/java/com/novoda/sqlite/model/Column.java
@@ -5,14 +5,14 @@ import com.novoda.sqlite.StringUtil;
 public final class Column {
     private final String name;
     private final String type;
-    private boolean nullable;
-    private DataAffinity affinity;
+    private final boolean nullable;
+    private final DataAffinity affinity;
 
     public Column(String name, String type, boolean nullable) {
         this.name = name;
         this.type = type;
         this.nullable = nullable;
-        this.affinity = computeAffinity(type);
+        this.affinity = DataAffinity.fromType(type);
     }
 
     public String getName() {
@@ -47,34 +47,5 @@ public final class Column {
         return affinity == DataAffinity.NUMERIC && type.toLowerCase().contains("bool");
     }
 
-    /*
- * See http://www.sqlite.org/datatype3.html
- * section 2.1 Determination of column affinity
- */
-    private DataAffinity computeAffinity(String type) {
-        String deftype = type.toLowerCase();
-        if (deftype.contains("int")) {
-            return DataAffinity.INTEGER;
-        }
-        if (containsOneOf(deftype, "char", "clob", "text")) {
-            return DataAffinity.TEXT;
-        }
-        if (containsOneOf(deftype, "real", "floa", "doub")) {
-            return DataAffinity.REAL;
-        }
-        if (containsOneOf(deftype, "blob") || deftype.equals("")) {
-            return DataAffinity.NONE;
-        }
-        return DataAffinity.NUMERIC;
-    }
-
-    private boolean containsOneOf(String toCheck, String... values) {
-        for (String value : values) {
-            if (toCheck.contains(value)) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 }

--- a/analyzer/src/main/java/com/novoda/sqlite/model/Column.java
+++ b/analyzer/src/main/java/com/novoda/sqlite/model/Column.java
@@ -25,9 +25,10 @@ public final class Column {
 
     public String getCamelizedSmallName() {
         String camel = StringUtil.camelify(name);
-        if (camel.length() <= 1)
-            return camel;
-        return camel.substring(0,1).toLowerCase()+camel.substring(1);
+        if (camel.length() <= 1) {
+            return "_" + camel;
+        }
+        return "_" + camel.substring(0, 1).toLowerCase() + camel.substring(1);
     }
 
     public String getType() {
@@ -43,7 +44,7 @@ public final class Column {
     }
 
     public boolean isBoolean() {
-        return  affinity == DataAffinity.NUMERIC && type.toLowerCase().contains("bool");
+        return affinity == DataAffinity.NUMERIC && type.toLowerCase().contains("bool");
     }
 
     /*
@@ -52,21 +53,26 @@ public final class Column {
  */
     private DataAffinity computeAffinity(String type) {
         String deftype = type.toLowerCase();
-        if (deftype.contains("int"))
+        if (deftype.contains("int")) {
             return DataAffinity.INTEGER;
-        if (containsOneOf(deftype, "char", "clob", "text"))
+        }
+        if (containsOneOf(deftype, "char", "clob", "text")) {
             return DataAffinity.TEXT;
-        if (containsOneOf(deftype, "real", "floa", "doub"))
+        }
+        if (containsOneOf(deftype, "real", "floa", "doub")) {
             return DataAffinity.REAL;
-        if (containsOneOf(deftype, "blob") || deftype.equals(""))
+        }
+        if (containsOneOf(deftype, "blob") || deftype.equals("")) {
             return DataAffinity.NONE;
+        }
         return DataAffinity.NUMERIC;
     }
 
     private boolean containsOneOf(String toCheck, String... values) {
         for (String value : values) {
-            if (toCheck.contains(value))
+            if (toCheck.contains(value)) {
                 return true;
+            }
         }
         return false;
     }

--- a/analyzer/src/main/java/com/novoda/sqlite/model/DataAffinity.java
+++ b/analyzer/src/main/java/com/novoda/sqlite/model/DataAffinity.java
@@ -1,5 +1,7 @@
 package com.novoda.sqlite.model;
 
+import java.util.Locale;
+
 public enum DataAffinity {
     TEXT, NUMERIC, INTEGER, REAL, NONE;
 
@@ -12,7 +14,7 @@ public enum DataAffinity {
      * section 2.1 Determination of column affinity
      */
     private static DataAffinity computeAffinity(String type) {
-        String deftype = type.toLowerCase();
+        String deftype = type.toLowerCase(Locale.US);
         if (deftype.contains("int")) {
             return DataAffinity.INTEGER;
         }

--- a/analyzer/src/main/java/com/novoda/sqlite/model/DataAffinity.java
+++ b/analyzer/src/main/java/com/novoda/sqlite/model/DataAffinity.java
@@ -2,4 +2,39 @@ package com.novoda.sqlite.model;
 
 public enum DataAffinity {
     TEXT, NUMERIC, INTEGER, REAL, NONE;
+
+    public static DataAffinity fromType(String type) {
+        return computeAffinity(type);
+    }
+
+    /**
+     * See http://www.sqlite.org/datatype3.html
+     * section 2.1 Determination of column affinity
+     */
+    private static DataAffinity computeAffinity(String type) {
+        String deftype = type.toLowerCase();
+        if (deftype.contains("int")) {
+            return DataAffinity.INTEGER;
+        }
+        if (containsOneOf(deftype, "char", "clob", "text")) {
+            return DataAffinity.TEXT;
+        }
+        if (containsOneOf(deftype, "real", "floa", "doub")) {
+            return DataAffinity.REAL;
+        }
+        if (containsOneOf(deftype, "blob") || deftype.equals("")) {
+            return DataAffinity.NONE;
+        }
+        return DataAffinity.NUMERIC;
+    }
+
+    private static boolean containsOneOf(String toCheck, String... values) {
+        for (String value : values) {
+            if (toCheck.contains(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 }

--- a/demo-assethelper/src/main/java/com/example/MainActivity.java
+++ b/demo-assethelper/src/main/java/com/example/MainActivity.java
@@ -23,7 +23,7 @@ public class MainActivity extends ListActivity {
 		ListAdapter adapter = new SimpleCursorAdapter(this, 
 				android.R.layout.simple_list_item_2,
 				employees, 
-				new String[] {Employees.FirstName, Employees.LastName},
+				new String[] {Employees.Firstname, Employees.Lastname},
 				new int[] {android.R.id.text1, android.R.id.text2});
 
 		getListView().setAdapter(adapter);

--- a/demo-assethelper/src/main/java/com/example/MyDatabase.java
+++ b/demo-assethelper/src/main/java/com/example/MyDatabase.java
@@ -31,7 +31,7 @@ public class MyDatabase extends SQLiteAssetHelper {
 		SQLiteDatabase db = getReadableDatabase();
 		SQLiteQueryBuilder qb = new SQLiteQueryBuilder();
 
-		String [] sqlSelect = {"0 _id", Employees.FirstName, Employees.LastName};
+		String [] sqlSelect = {"0 _id", Employees.Firstname, Employees.Lastname};
 		String sqlTables = DB.Tables.Employees;
 
 		qb.setTables(sqlTables);

--- a/demo-auto/src/main/java/com/example/MainActivity.java
+++ b/demo-auto/src/main/java/com/example/MainActivity.java
@@ -23,7 +23,7 @@ public class MainActivity extends ListActivity {
 		ListAdapter adapter = new SimpleCursorAdapter(this, 
 				android.R.layout.simple_list_item_2,
 				employees, 
-				new String[] {Employees.FirstName, Employees.LastName},
+				new String[] {Employees.Firstname, Employees.Lastname},
 				new int[] {android.R.id.text1, android.R.id.text2});
 
 		getListView().setAdapter(adapter);

--- a/demo-auto/src/main/java/com/example/MyDatabase.java
+++ b/demo-auto/src/main/java/com/example/MyDatabase.java
@@ -31,7 +31,7 @@ public class MyDatabase extends SQLiteAssetHelper {
 		SQLiteDatabase db = getReadableDatabase();
 		SQLiteQueryBuilder qb = new SQLiteQueryBuilder();
 
-		String [] sqlSelect = {"0 _id", Employees.FirstName, Employees.LastName};
+		String [] sqlSelect = {"0 _id", Employees.Firstname, Employees.Lastname};
 		String sqlTables = DB.Tables.Employees;
 
 		qb.setTables(sqlTables);


### PR DESCRIPTION
- fixes wrong camel casing when column names are all uppercase
- adds an additional underscore to the variable name for a column to avoid clashes with java keywords like `default` or the likes
- moves the mapping from column type to DataAffinity into the `DataAffinity` class