### PR TITLE
Add analyzer module back in settings.gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,3 @@
 include 'demo-assethelper', 'demo-sqliteprovider', 'demo-auto'
+include ':analyzer'
 


### PR DESCRIPTION
@devisnik @stefanhoth Not sure why it was [removed](https://github.com/novoda/sqlite-analyzer/commit/b96b8191c68793198072484afd3ee511c065a6a7), so would prefer input from these fellows.

- the bintray release plugin is found in here and without this module the CI build will crash (uses bintrayUpload)