### PR TITLE
4/java doc and format

### DIFF
--- a/analyzer/src/main/groovy/com/novoda/sqlite/generator/GetColumnFromCursorGenerator.groovy
+++ b/analyzer/src/main/groovy/com/novoda/sqlite/generator/GetColumnFromCursorGenerator.groovy
@@ -7,13 +7,13 @@ class GetColumnFromCursorGenerator {
 
     private static final String TEMPLATE = '''\
 public static $returnType $prefix$methodName(android.database.Cursor cursor) {
-  int index = cursor.getColumnIndexOrThrow("$rowName");\
+    int index = cursor.getColumnIndexOrThrow("$rowName");\
 <% if(nullable) {%>
-  if (cursor.isNull(index)) {
-    return null;
-  }\
+    if (cursor.isNull(index)) {
+        return null;
+    }\
 <% } %>
-  return cursor.get$cursorFunction(index)<% if (isBool) out << " > 0" %>;
+    return cursor.get$cursorFunction(index)<% if (isBool) out << " > 0" %>;
 }
 '''
     private final Column column

--- a/analyzer/src/main/groovy/com/novoda/sqlite/generator/GetFieldGenerator.groovy
+++ b/analyzer/src/main/groovy/com/novoda/sqlite/generator/GetFieldGenerator.groovy
@@ -6,8 +6,11 @@ import groovy.text.GStringTemplateEngine
 class GetFieldGenerator {
 
     private static final String TEMPLATE = '''\
+/**
+* derived from sqlite row: name=$rowName affinity=$affinity
+*/
 public $returnType $prefix$methodName() {
-  return $variableName;
+    return $variableName;
 }
 '''
     private final Column column
@@ -21,7 +24,9 @@ public $returnType $prefix$methodName() {
                 .make([returnType: column.dataType,
                 methodName: column.camelizedName,
                 variableName: column.camelizedSmallName,
-                prefix: column.getterPrefix])
+                prefix: column.getterPrefix,
+                rowName: column.name,
+                affinity: column.affinity])
                 .toString()
     }
 }

--- a/analyzer/src/main/groovy/com/novoda/sqlite/generator/GetFieldGenerator.groovy
+++ b/analyzer/src/main/groovy/com/novoda/sqlite/generator/GetFieldGenerator.groovy
@@ -7,8 +7,8 @@ class GetFieldGenerator {
 
     private static final String TEMPLATE = '''\
 /**
-* derived from sqlite row: name=$rowName affinity=$affinity
-*/
+ * Generated from the sqlite column named $rowName with an affinity of $affinity.
+ */
 public $returnType $prefix$methodName() {
     return $variableName;
 }

--- a/analyzer/src/main/groovy/com/novoda/sqlite/generator/TableColumnsGenerator.groovy
+++ b/analyzer/src/main/groovy/com/novoda/sqlite/generator/TableColumnsGenerator.groovy
@@ -8,6 +8,9 @@ public class TableColumnsGenerator {
     private static final String TEMPLATE = '''\
 public static final class $classname {
 <% columns.each { column ->  %>\
+    /**
+    * derived from sqlite: name=${column.name} affinity=${column.affinity}
+    */
     public static final String ${column.camelizedName} = "${column.name}";
 <% } %>\
 }

--- a/analyzer/src/main/groovy/com/novoda/sqlite/generator/TableColumnsGenerator.groovy
+++ b/analyzer/src/main/groovy/com/novoda/sqlite/generator/TableColumnsGenerator.groovy
@@ -9,8 +9,8 @@ public class TableColumnsGenerator {
 public static final class $classname {
 <% columns.each { column ->  %>\
     /**
-    * derived from sqlite: name=${column.name} affinity=${column.affinity}
-    */
+     * Generated from the sqlite column named ${column.name} with an affinity of ${column.affinity}.
+     */
     public static final String ${column.camelizedName} = "${column.name}";
 <% } %>\
 }

--- a/analyzer/src/test/java/com/novoda/sqlite/StringUtilTest.java
+++ b/analyzer/src/test/java/com/novoda/sqlite/StringUtilTest.java
@@ -2,20 +2,48 @@ package com.novoda.sqlite;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
+import static com.novoda.sqlite.StringUtil.*;
 
 public class StringUtilTest {
+
     @Test
-    public void shouldCamelizeColumnNames(){
-        assertEquals("ColumnId", StringUtil.camelify("COLUMN_ID"));
-        assertEquals("Columnid", StringUtil.camelify("columnID"));
-        assertEquals("Columnid", StringUtil.camelify("COLUMNID"));
+    public void shouldCamelizeAllUppercaseUnderscoredColumn() {
+        assertEquals("ColumnId", camelify("COLUMN_ID"));
     }
 
     @Test
-    public void shouldCamelizeColumnNamesForMethods() {
-        assertEquals("getColumnId", StringUtil.asCamelifyGetMethod("COLUMN_ID"));
-        assertEquals("getColumnid", StringUtil.asCamelifyGetMethod("columnID"));
-        assertEquals("getColumnid", StringUtil.asCamelifyGetMethod("COLUMNID"));
+    public void shouldCamelizeLowerUnderscoredColumn() {
+        assertEquals("ColumnId", camelify("column_id"));
+    }
+
+    @Test
+    public void shouldCamelizeMixedcaseColumn() {
+        assertEquals("Columnid", camelify("columnID"));
+    }
+
+    @Test
+    public void shouldCamelizeAllUppercaseColumn() {
+        assertEquals("Columnid", camelify("COLUMNID"));
+    }
+
+    @Test
+    public void shouldCamelizeGetterForAllUppercaseUnderscoredColumn() {
+        assertEquals("getColumnId", asCamelifyGetMethod("COLUMN_ID"));
+    }
+
+    @Test
+    public void shouldCamelizeGetterForAllLowercaseUnderscoredColumn() {
+        assertEquals("getColumnId", asCamelifyGetMethod("column_id"));
+    }
+
+    @Test
+    public void shouldCamelizeGetterForMixedcaseColumn() {
+        assertEquals("getColumnid", asCamelifyGetMethod("columnID"));
+    }
+
+    @Test
+    public void shouldCamelizeGetterForAllUppercaseColumn() {
+        assertEquals("getColumnid", asCamelifyGetMethod("COLUMNID"));
     }
 }

--- a/analyzer/src/test/java/com/novoda/sqlite/StringUtilTest.java
+++ b/analyzer/src/test/java/com/novoda/sqlite/StringUtilTest.java
@@ -1,0 +1,21 @@
+package com.novoda.sqlite;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class StringUtilTest {
+    @Test
+    public void shouldCamelizeColumnNames(){
+        assertEquals("ColumnId", StringUtil.camelify("COLUMN_ID"));
+        assertEquals("Columnid", StringUtil.camelify("columnID"));
+        assertEquals("Columnid", StringUtil.camelify("COLUMNID"));
+    }
+
+    @Test
+    public void shouldCamelizeColumnNamesForMethods() {
+        assertEquals("getColumnId", StringUtil.asCamelifyGetMethod("COLUMN_ID"));
+        assertEquals("getColumnid", StringUtil.asCamelifyGetMethod("columnID"));
+        assertEquals("getColumnid", StringUtil.asCamelifyGetMethod("COLUMNID"));
+    }
+}

--- a/analyzer/src/test/java/com/novoda/sqlite/StringUtilTest.java
+++ b/analyzer/src/test/java/com/novoda/sqlite/StringUtilTest.java
@@ -2,8 +2,9 @@ package com.novoda.sqlite;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-import static com.novoda.sqlite.StringUtil.*;
+import static org.junit.Assert.assertEquals;
+import static com.novoda.sqlite.StringUtil.camelify;
+import static com.novoda.sqlite.StringUtil.asCamelifyGetMethod;
 
 public class StringUtilTest {
 


### PR DESCRIPTION
This PR adds java doc to the generated code to document the sqlite table columns. 

It also uses 4 spaces for indent.