### PR TITLE
Allow changing access model

### DIFF
--- a/analyzer/src/main/groovy/com/novoda/sqlite/generator/model/Access.groovy
+++ b/analyzer/src/main/groovy/com/novoda/sqlite/generator/model/Access.groovy
@@ -1,12 +1,14 @@
 package com.novoda.sqlite.generator.model
 import com.novoda.sqlite.model.Database
 import com.novoda.sqlite.model.Table
+import groovy.transform.CompileStatic
 
+@CompileStatic
 class Access {
     Collection<DataSet> tables
 
     static Access from(Database database) {
-        [tables: tablesToDataSets(database.tables)]
+        [tables: tablesToDataSets(database.tables)] as Access
     }
 
     private static Collection<DataSet> tablesToDataSets(Collection<Table> tables) {

--- a/analyzer/src/main/groovy/com/novoda/sqlite/generator/model/DataSet.groovy
+++ b/analyzer/src/main/groovy/com/novoda/sqlite/generator/model/DataSet.groovy
@@ -1,17 +1,16 @@
 package com.novoda.sqlite.generator.model
-
 import com.novoda.sqlite.model.Column
 import com.novoda.sqlite.model.Table
-import groovy.transform.Immutable
+import groovy.transform.CompileStatic
 
-@Immutable
+@CompileStatic
 class DataSet {
     String sqlName
     String name
     Collection<Field> fields
 
     static DataSet fromTable(Table table) {
-        return [sqlName: table.name, name: table.camelizedName, fields: columnsToFields(table.columns)]
+        [sqlName: table.name, name: table.camelizedName, fields: columnsToFields(table.columns)] as DataSet
     }
 
     private static Collection<Field> columnsToFields(Collection<Column> columns) {

--- a/analyzer/src/main/groovy/com/novoda/sqlite/generator/model/Field.groovy
+++ b/analyzer/src/main/groovy/com/novoda/sqlite/generator/model/Field.groovy
@@ -1,10 +1,9 @@
 package com.novoda.sqlite.generator.model
-
 import com.novoda.sqlite.model.Column
 import com.novoda.sqlite.model.DataAffinity
-import groovy.transform.Immutable
+import groovy.transform.CompileStatic
 
-@Immutable
+@CompileStatic
 final class Field {
     String name
     String accessor
@@ -16,14 +15,14 @@ final class Field {
     String cursorType
 
     static Field fromColumn(Column column) {
-        return [name      : column.camelizedSmallName,
-                accessor  : column.camelizedName,
-                sqlName   : column.name,
-                getMethod : getGetterPrefix(column) + column.camelizedName,
-                setMethod : 'set' + column.camelizedName,
-                type      : getDataType(column),
-                optional  : column.nullable,
-                cursorType: getCursorAccessor(column)]
+        [name      : column.camelizedSmallName,
+         accessor  : column.camelizedName,
+         sqlName   : column.name,
+         getMethod : getGetterPrefix(column) + column.camelizedName,
+         setMethod : 'set' + column.camelizedName,
+         type      : getDataType(column),
+         optional  : column.nullable,
+         cursorType: getCursorAccessor(column)] as Field
     }
 
     private static String getDataType(Column column) {

--- a/demo-sqliteprovider/build.gradle
+++ b/demo-sqliteprovider/build.gradle
@@ -22,5 +22,14 @@ dependencies {
 sqliteAccess {
     migrationsDir 'src/main/assets/migrations'
     packageName 'com.novoda.sqliteprovider.demo.simple'
-    generator staticAccessGenerator()
+    generator { database, basedir ->
+        def access = access(database)
+        access.tables.each { table ->
+            table.fields.each { field ->
+                if (field.type == 'Integer') {field.type = 'Long'; field.cursorType = 'Long'}
+                if (field.type == 'int') {field.type = 'long'; field.cursorType = 'Long'}
+            }
+        }
+        generateClass(file('code.template'), access, "DB", packageName, basedir)
+    }
 }

--- a/demo-sqliteprovider/code.template
+++ b/demo-sqliteprovider/code.template
@@ -1,0 +1,29 @@
+package $packageName;
+
+public final class $className {
+public static final class Tables {
+<% access.tables.each { dataSet -> %>    public static final String $dataSet.name = "$dataSet.sqlName";
+<% } %>}
+
+public static final class Columns {
+<% access.tables.each { dataSet -> %>    public static final class $dataSet.name {
+<%      dataSet.fields.each { field -> %>        public static final String $field.accessor = "$field.sqlName";
+<%      } %>    }
+<% } %>}
+
+<% access.tables.each { dataSet -> %>public static final class $dataSet.name {
+<% dataSet.fields.each { field -> %>
+public static $field.type $field.getMethod(android.database.Cursor cursor) {
+        int index = cursor.getColumnIndexOrThrow("$field.sqlName");
+<% if(field.optional) {%>
+        if (cursor.isNull(index)) {
+            return null;
+        }
+<% } %>
+        return cursor.get$field.cursorType(index)<% if (field.type ==~ /^(?i)boolean$/) out << " > 0" %>;
+    }
+    public static void $field.setMethod($field.type value, android.content.ContentValues values) {
+        values.put("$field.sqlName", value);
+    }
+<% } %>}
+<% } %>}


### PR DESCRIPTION
- allows the access model used in code generation to be edited
- makes access model classes `@CompileStatic`
- adds some sample custom code generation to the `demo-sqliteprovider` samples