### PR TITLE
Add utility conversion methods

### DIFF
--- a/analyzer/src/main/groovy/com/novoda/sqlite/generator/Templates.groovy
+++ b/analyzer/src/main/groovy/com/novoda/sqlite/generator/Templates.groovy
@@ -63,6 +63,13 @@ public static final class $dataSet.name {
         return $field.name;
     }
 <% } %>\
+    public android.content.ContentValues toContentValues() {
+        android.content.ContentValues values = new android.content.ContentValues();
+<% dataSet.fields.each { field -> %>\
+        $field.setMethod($field.name, values);
+<% } %>\
+        return values;
+    }
 }
 <% } %>\
 }

--- a/analyzer/src/main/groovy/com/novoda/sqlite/generator/Templates.groovy
+++ b/analyzer/src/main/groovy/com/novoda/sqlite/generator/Templates.groovy
@@ -42,13 +42,9 @@ public static final class $dataSet.name {
     public static $dataSet.name fromCursor(android.database.Cursor cursor) {
 <% dataSet.fields.each { field -> %>\
         $field.type $field.name = $field.getMethod(cursor);
-<% } %>
-    return new $dataSet.name(\
-<% dataSet.fields.eachWithIndex { field, index ->
-    out << field.name
-    if (index < dataSet.fields.size()-1)
-      out << ", "
-} %>);
+<% } %>\
+        return new $dataSet.name(\
+<% out << dataSet.fields.collect { it.name }.join(', ') %>);
     }
 
 <% dataSet.fields.each { field -> %>\
@@ -56,11 +52,7 @@ public static final class $dataSet.name {
 <% } %>\
 
     public $dataSet.name(\
-<% dataSet.fields.eachWithIndex { field, index ->
-    out << "$field.type $field.name"
-    if (index < dataSet.fields.size()-1)
-      out << ", "
-} %>) {
+<% out << dataSet.fields.collect {"$it.type $it.name"}.join(', ') %>) {
 <% dataSet.fields.each { field -> %>\
         this.$field.name = $field.name;
 <% } %>\

--- a/analyzer/src/main/groovy/com/novoda/sqlite/generator/Templates.groovy
+++ b/analyzer/src/main/groovy/com/novoda/sqlite/generator/Templates.groovy
@@ -39,6 +39,18 @@ public static final class $dataSet.name {
     }
 <% } %>\
 
+    public static $dataSet.name fromCursor(android.database.Cursor cursor) {
+<% dataSet.fields.each { field -> %>\
+        $field.type $field.name = $field.getMethod(cursor);
+<% } %>
+    return new $dataSet.name(\
+<% dataSet.fields.eachWithIndex { field, index ->
+    out << field.name
+    if (index < dataSet.fields.size()-1)
+      out << ", "
+} %>);
+    }
+
 <% dataSet.fields.each { field -> %>\
     private final $field.type $field.name;
 <% } %>\


### PR DESCRIPTION
- adds static `fromCursor` method to default template
- adds `toContentValues` method to default template
- uses better string joining