### PR TITLE
Test SQLFile with all the possible (handled) use cases

### DIFF
--- a/analyzer/src/test/java/com/novoda/sqlite/impl/SQLFileTest.java
+++ b/analyzer/src/test/java/com/novoda/sqlite/impl/SQLFileTest.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.List;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 public class SQLFileTest {
     private final static String STATEMENT_CREATE_TABLE = "CREATE TABLE banana(_id INTEGER);";
@@ -22,7 +24,7 @@ public class SQLFileTest {
 
         String[] actual = getStatementsFromFile(file);
 
-        Assert.assertArrayEquals(actual, EXPECTED_STATEMENTS);
+        assertArrayEquals(actual, EXPECTED_STATEMENTS);
     }
 
     @Test
@@ -31,7 +33,7 @@ public class SQLFileTest {
 
         String[] actual = getStatementsFromFile(file);
 
-        Assert.assertArrayEquals(actual, EXPECTED_STATEMENTS);
+        assertArrayEquals(actual, EXPECTED_STATEMENTS);
     }
 
     @Test
@@ -41,7 +43,7 @@ public class SQLFileTest {
 
         String[] actual = getStatementsFromFile(file);
 
-        Assert.assertArrayEquals(actual, EXPECTED_STATEMENTS);
+        assertArrayEquals(actual, EXPECTED_STATEMENTS);
     }
 
     @Test
@@ -51,7 +53,7 @@ public class SQLFileTest {
 
         String[] actual = getStatementsFromFile(file);
 
-        Assert.assertArrayEquals(actual, EXPECTED_STATEMENTS);
+        assertArrayEquals(actual, EXPECTED_STATEMENTS);
     }
 
     private SQLFile givenSQLFileParsedFromString(String sql) throws IOException {

--- a/analyzer/src/test/java/com/novoda/sqlite/impl/SQLFileTest.java
+++ b/analyzer/src/test/java/com/novoda/sqlite/impl/SQLFileTest.java
@@ -22,7 +22,7 @@ public class SQLFileTest {
 
     @Test
     public void givenSQLFile_whenParse_thenGetCorrectStatements() throws IOException {
-        SQLFile sqlFile = givenSQLFileWhenParse(String.format("%s\n%s", STATEMENT_CREATE_TABLE, STATEMENT_ALTER_TABLE));
+        SQLFile sqlFile = givenSQLFileWhenParse(STATEMENT_CREATE_TABLE + NEW_LINE + STATEMENT_ALTER_TABLE);
 
         String[] actual = getStatementsFromFile(sqlFile);
         assertArrayEquals(actual, EXPECTED_STATEMENTS);

--- a/analyzer/src/test/java/com/novoda/sqlite/impl/SQLFileTest.java
+++ b/analyzer/src/test/java/com/novoda/sqlite/impl/SQLFileTest.java
@@ -1,0 +1,67 @@
+package com.novoda.sqlite.impl;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SQLFileTest {
+    private final static String STATEMENT_CREATE_TABLE = "CREATE TABLE banana(_id INTEGER);";
+    private final static String STATEMENT_ALTER_TABLE = "ALTER TABLE banana ADD COLUMN colour TEXT;";
+    private final static String NEW_LINE = "\n";
+    private final static String SPACE = " ";
+    private final static String LINE_COMMENT = "-- this is a line comment";
+    private final static String[] EXPECTED_STATEMENTS = new String[]{STATEMENT_CREATE_TABLE, STATEMENT_ALTER_TABLE};
+    private static final String BLOCK_COMMENT = "/* this is a \n block comment \n spanning over \n multiple lines */";
+
+    @Test
+    public void givenSQLFile_whenParseAndGetStatements_thenGetCorrectStatements() throws IOException {
+        SQLFile file = givenSQLFileParsedFromString(STATEMENT_CREATE_TABLE + NEW_LINE + STATEMENT_ALTER_TABLE);
+
+        String[] actual = getStatementsFromFile(file);
+
+        Assert.assertArrayEquals(actual, EXPECTED_STATEMENTS);
+    }
+
+    @Test
+    public void givenSQLFileWithSpaces_whenParseAndGetStatements_thenGetCorrectTrimmedStatements() throws IOException {
+        SQLFile file = givenSQLFileParsedFromString(SPACE + STATEMENT_CREATE_TABLE + SPACE + NEW_LINE + SPACE + STATEMENT_ALTER_TABLE + SPACE);
+
+        String[] actual = getStatementsFromFile(file);
+
+        Assert.assertArrayEquals(actual, EXPECTED_STATEMENTS);
+    }
+
+    @Test
+    public void givenSQLFileWithLineComments_whenParseAndGetStatements_thenIgnoreComments() throws IOException {
+        SQLFile file = givenSQLFileParsedFromString(
+                STATEMENT_CREATE_TABLE + SPACE + LINE_COMMENT + NEW_LINE + STATEMENT_ALTER_TABLE + SPACE + LINE_COMMENT);
+
+        String[] actual = getStatementsFromFile(file);
+
+        Assert.assertArrayEquals(actual, EXPECTED_STATEMENTS);
+    }
+
+    @Test
+    public void givenSQLFileWithBlockComments_whenParseAndGetStatements_thenIgnoreComments() throws IOException {
+        SQLFile file = givenSQLFileParsedFromString(
+                STATEMENT_CREATE_TABLE + NEW_LINE + BLOCK_COMMENT + NEW_LINE + STATEMENT_ALTER_TABLE);
+
+        String[] actual = getStatementsFromFile(file);
+
+        Assert.assertArrayEquals(actual, EXPECTED_STATEMENTS);
+    }
+
+    private SQLFile givenSQLFileParsedFromString(String sql) throws IOException {
+        SQLFile file = new SQLFile();
+        file.parse(new StringReader(sql));
+        return file;
+    }
+
+    private String[] getStatementsFromFile(SQLFile file) {
+        List<String> statements = file.getStatements();
+        return statements.toArray(new String[statements.size()]);
+    }
+}

--- a/analyzer/src/test/java/com/novoda/sqlite/impl/SQLFileTest.java
+++ b/analyzer/src/test/java/com/novoda/sqlite/impl/SQLFileTest.java
@@ -41,7 +41,8 @@ public class SQLFileTest {
     @Test
     public void givenSQLFileWithLineComments_whenParseAndGetStatements_thenIgnoreComments() throws IOException {
         SQLFile file = givenSQLFileParsedFromString(
-                STATEMENT_CREATE_TABLE + SPACE + LINE_COMMENT + NEW_LINE + STATEMENT_ALTER_TABLE + SPACE + LINE_COMMENT);
+                STATEMENT_CREATE_TABLE + SPACE + LINE_COMMENT + NEW_LINE + STATEMENT_ALTER_TABLE + SPACE + LINE_COMMENT
+        );
 
         String[] actual = getStatementsFromFile(file);
 
@@ -61,7 +62,8 @@ public class SQLFileTest {
     @Test
     public void givenSQLFileWithLineCommentsWithinStatement_whenParseAndGetStatements_thenIgnoreComments() throws IOException {
         SQLFile file = givenSQLFileParsedFromString(
-                STATEMENT_FOR_COMMENTS_WITHIN_TESTS_1 + NEW_LINE + LINE_COMMENT + NEW_LINE + STATEMENT_FOR_COMMENTS_WITHIN_TESTS_2);
+                STATEMENT_FOR_COMMENTS_WITHIN_TESTS_1 + NEW_LINE + LINE_COMMENT + NEW_LINE + STATEMENT_FOR_COMMENTS_WITHIN_TESTS_2
+        );
 
         String[] actual = getStatementsFromFile(file);
 
@@ -72,7 +74,8 @@ public class SQLFileTest {
     @Test
     public void givenSQLFileWithBlockCommentsWithinStatement_whenParseAndGetStatements_thenIgnoreComments() throws IOException {
         SQLFile file = givenSQLFileParsedFromString(
-                STATEMENT_FOR_COMMENTS_WITHIN_TESTS_1 + NEW_LINE + BLOCK_COMMENT + NEW_LINE + STATEMENT_FOR_COMMENTS_WITHIN_TESTS_2);
+                STATEMENT_FOR_COMMENTS_WITHIN_TESTS_1 + NEW_LINE + BLOCK_COMMENT + NEW_LINE + STATEMENT_FOR_COMMENTS_WITHIN_TESTS_2
+        );
 
         String[] actual = getStatementsFromFile(file);
 

--- a/analyzer/src/test/java/com/novoda/sqlite/impl/SQLFileTest.java
+++ b/analyzer/src/test/java/com/novoda/sqlite/impl/SQLFileTest.java
@@ -14,9 +14,11 @@ public class SQLFileTest {
     private final static String STATEMENT_ALTER_TABLE = "ALTER TABLE banana ADD COLUMN colour TEXT;";
     private final static String NEW_LINE = "\n";
     private final static String SPACE = " ";
-    private final static String LINE_COMMENT = "-- this is a line comment";
     private final static String[] EXPECTED_STATEMENTS = new String[]{STATEMENT_CREATE_TABLE, STATEMENT_ALTER_TABLE};
+    private final static String LINE_COMMENT = "-- this is a line comment";
     private static final String BLOCK_COMMENT = "/* this is a \n block comment \n spanning over \n multiple lines */";
+    private final static String STATEMENT_FOR_COMMENTS_WITHIN_TESTS_1 = "CREATE TABLE";
+    private final static String STATEMENT_FOR_COMMENTS_WITHIN_TESTS_2 = "banana(_id INTEGER);";
 
     @Test
     public void givenSQLFile_whenParseAndGetStatements_thenGetCorrectStatements() throws IOException {
@@ -54,6 +56,28 @@ public class SQLFileTest {
         String[] actual = getStatementsFromFile(file);
 
         assertArrayEquals(actual, EXPECTED_STATEMENTS);
+    }
+
+    @Test
+    public void givenSQLFileWithLineCommentsWithinStatement_whenParseAndGetStatements_thenIgnoreComments() throws IOException {
+        SQLFile file = givenSQLFileParsedFromString(
+                STATEMENT_FOR_COMMENTS_WITHIN_TESTS_1 + NEW_LINE + LINE_COMMENT + NEW_LINE + STATEMENT_FOR_COMMENTS_WITHIN_TESTS_2);
+
+        String[] actual = getStatementsFromFile(file);
+
+        assertEquals(actual.length, 1);
+        assertEquals(actual[0], STATEMENT_FOR_COMMENTS_WITHIN_TESTS_1 + SPACE + STATEMENT_FOR_COMMENTS_WITHIN_TESTS_2);
+    }
+
+    @Test
+    public void givenSQLFileWithBlockCommentsWithinStatement_whenParseAndGetStatements_thenIgnoreComments() throws IOException {
+        SQLFile file = givenSQLFileParsedFromString(
+                STATEMENT_FOR_COMMENTS_WITHIN_TESTS_1 + NEW_LINE + BLOCK_COMMENT + NEW_LINE + STATEMENT_FOR_COMMENTS_WITHIN_TESTS_2);
+
+        String[] actual = getStatementsFromFile(file);
+
+        assertEquals(actual.length, 1);
+        assertEquals(actual[0], STATEMENT_FOR_COMMENTS_WITHIN_TESTS_1 + SPACE + STATEMENT_FOR_COMMENTS_WITHIN_TESTS_2);
     }
 
     private SQLFile givenSQLFileParsedFromString(String sql) throws IOException {

--- a/analyzer/src/test/java/com/novoda/sqlite/impl/SQLFileTest.java
+++ b/analyzer/src/test/java/com/novoda/sqlite/impl/SQLFileTest.java
@@ -85,9 +85,9 @@ public class SQLFileTest {
     }
 
     private SQLFile givenSQLFileParsedFromString(String sql) throws IOException {
-        SQLFile file = new SQLFile();
-        file.parse(new StringReader(sql));
-        return file;
+        SQLFile sqlFile = new SQLFile();
+        sqlFile.parse(new StringReader(sql));
+        return sqlFile;
     }
 
     private String[] getStatementsFromFile(SQLFile file) {

--- a/analyzer/src/test/java/com/novoda/sqlite/impl/SQLFileTest.java
+++ b/analyzer/src/test/java/com/novoda/sqlite/impl/SQLFileTest.java
@@ -21,70 +21,64 @@ public class SQLFileTest {
     private final static String STATEMENT_FOR_COMMENTS_WITHIN_TESTS_2 = "banana(_id INTEGER);";
 
     @Test
-    public void givenSQLFile_whenParseAndGetStatements_thenGetCorrectStatements() throws IOException {
-        SQLFile file = givenSQLFileParsedFromString(STATEMENT_CREATE_TABLE + NEW_LINE + STATEMENT_ALTER_TABLE);
+    public void givenSQLFile_whenParse_thenGetCorrectStatements() throws IOException {
+        SQLFile file = givenSQLFileWhenParse(String.format("%s\n%s", STATEMENT_CREATE_TABLE, STATEMENT_ALTER_TABLE));
 
         String[] actual = getStatementsFromFile(file);
-
         assertArrayEquals(actual, EXPECTED_STATEMENTS);
     }
 
     @Test
-    public void givenSQLFileWithSpaces_whenParseAndGetStatements_thenGetCorrectTrimmedStatements() throws IOException {
-        SQLFile file = givenSQLFileParsedFromString(SPACE + STATEMENT_CREATE_TABLE + SPACE + NEW_LINE + SPACE + STATEMENT_ALTER_TABLE + SPACE);
+    public void givenSQLFileWithSpaces_whenParse_thenGetCorrectTrimmedStatements() throws IOException {
+        SQLFile file = givenSQLFileWhenParse(SPACE + STATEMENT_CREATE_TABLE + SPACE + NEW_LINE + SPACE + STATEMENT_ALTER_TABLE + SPACE);
 
         String[] actual = getStatementsFromFile(file);
-
         assertArrayEquals(actual, EXPECTED_STATEMENTS);
     }
 
     @Test
-    public void givenSQLFileWithLineComments_whenParseAndGetStatements_thenIgnoreComments() throws IOException {
-        SQLFile file = givenSQLFileParsedFromString(
+    public void givenSQLFileWithLineComments_whenParse_thenIgnoreComments() throws IOException {
+        SQLFile file = givenSQLFileWhenParse(
                 STATEMENT_CREATE_TABLE + SPACE + LINE_COMMENT + NEW_LINE + STATEMENT_ALTER_TABLE + SPACE + LINE_COMMENT
         );
 
         String[] actual = getStatementsFromFile(file);
-
         assertArrayEquals(actual, EXPECTED_STATEMENTS);
     }
 
     @Test
-    public void givenSQLFileWithBlockComments_whenParseAndGetStatements_thenIgnoreComments() throws IOException {
-        SQLFile file = givenSQLFileParsedFromString(
+    public void givenSQLFileWithBlockComments_whenParse_thenIgnoreComments() throws IOException {
+        SQLFile file = givenSQLFileWhenParse(
                 STATEMENT_CREATE_TABLE + NEW_LINE + BLOCK_COMMENT + NEW_LINE + STATEMENT_ALTER_TABLE
         );
 
         String[] actual = getStatementsFromFile(file);
-
         assertArrayEquals(actual, EXPECTED_STATEMENTS);
     }
 
     @Test
-    public void givenSQLFileWithLineCommentsWithinStatement_whenParseAndGetStatements_thenIgnoreComments() throws IOException {
-        SQLFile file = givenSQLFileParsedFromString(
+    public void givenSQLFileWithLineCommentsWithinStatement_whenParse_thenIgnoreComments() throws IOException {
+        SQLFile file = givenSQLFileWhenParse(
                 STATEMENT_FOR_COMMENTS_WITHIN_TESTS_1 + NEW_LINE + LINE_COMMENT + NEW_LINE + STATEMENT_FOR_COMMENTS_WITHIN_TESTS_2
         );
 
         String[] actual = getStatementsFromFile(file);
-
         assertEquals(actual.length, 1);
         assertEquals(actual[0], STATEMENT_FOR_COMMENTS_WITHIN_TESTS_1 + SPACE + STATEMENT_FOR_COMMENTS_WITHIN_TESTS_2);
     }
 
     @Test
-    public void givenSQLFileWithBlockCommentsWithinStatement_whenParseAndGetStatements_thenIgnoreComments() throws IOException {
-        SQLFile file = givenSQLFileParsedFromString(
+    public void givenSQLFileWithBlockCommentsWithinStatement_whenParse_thenIgnoreComments() throws IOException {
+        SQLFile file = givenSQLFileWhenParse(
                 STATEMENT_FOR_COMMENTS_WITHIN_TESTS_1 + NEW_LINE + BLOCK_COMMENT + NEW_LINE + STATEMENT_FOR_COMMENTS_WITHIN_TESTS_2
         );
 
         String[] actual = getStatementsFromFile(file);
-
         assertEquals(actual.length, 1);
         assertEquals(actual[0], STATEMENT_FOR_COMMENTS_WITHIN_TESTS_1 + SPACE + STATEMENT_FOR_COMMENTS_WITHIN_TESTS_2);
     }
 
-    private SQLFile givenSQLFileParsedFromString(String sql) throws IOException {
+    private SQLFile givenSQLFileWhenParse(String sql) throws IOException {
         SQLFile sqlFile = new SQLFile();
         sqlFile.parse(new StringReader(sql));
         return sqlFile;

--- a/analyzer/src/test/java/com/novoda/sqlite/impl/SQLFileTest.java
+++ b/analyzer/src/test/java/com/novoda/sqlite/impl/SQLFileTest.java
@@ -52,7 +52,8 @@ public class SQLFileTest {
     @Test
     public void givenSQLFileWithBlockComments_whenParseAndGetStatements_thenIgnoreComments() throws IOException {
         SQLFile file = givenSQLFileParsedFromString(
-                STATEMENT_CREATE_TABLE + NEW_LINE + BLOCK_COMMENT + NEW_LINE + STATEMENT_ALTER_TABLE);
+                STATEMENT_CREATE_TABLE + NEW_LINE + BLOCK_COMMENT + NEW_LINE + STATEMENT_ALTER_TABLE
+        );
 
         String[] actual = getStatementsFromFile(file);
 

--- a/analyzer/src/test/java/com/novoda/sqlite/impl/SQLFileTest.java
+++ b/analyzer/src/test/java/com/novoda/sqlite/impl/SQLFileTest.java
@@ -22,58 +22,58 @@ public class SQLFileTest {
 
     @Test
     public void givenSQLFile_whenParse_thenGetCorrectStatements() throws IOException {
-        SQLFile file = givenSQLFileWhenParse(String.format("%s\n%s", STATEMENT_CREATE_TABLE, STATEMENT_ALTER_TABLE));
+        SQLFile sqlFile = givenSQLFileWhenParse(String.format("%s\n%s", STATEMENT_CREATE_TABLE, STATEMENT_ALTER_TABLE));
 
-        String[] actual = getStatementsFromFile(file);
+        String[] actual = getStatementsFromFile(sqlFile);
         assertArrayEquals(actual, EXPECTED_STATEMENTS);
     }
 
     @Test
     public void givenSQLFileWithSpaces_whenParse_thenGetCorrectTrimmedStatements() throws IOException {
-        SQLFile file = givenSQLFileWhenParse(SPACE + STATEMENT_CREATE_TABLE + SPACE + NEW_LINE + SPACE + STATEMENT_ALTER_TABLE + SPACE);
+        SQLFile sqlFile = givenSQLFileWhenParse(SPACE + STATEMENT_CREATE_TABLE + SPACE + NEW_LINE + SPACE + STATEMENT_ALTER_TABLE + SPACE);
 
-        String[] actual = getStatementsFromFile(file);
+        String[] actual = getStatementsFromFile(sqlFile);
         assertArrayEquals(actual, EXPECTED_STATEMENTS);
     }
 
     @Test
     public void givenSQLFileWithLineComments_whenParse_thenIgnoreComments() throws IOException {
-        SQLFile file = givenSQLFileWhenParse(
+        SQLFile sqlFile = givenSQLFileWhenParse(
                 STATEMENT_CREATE_TABLE + SPACE + LINE_COMMENT + NEW_LINE + STATEMENT_ALTER_TABLE + SPACE + LINE_COMMENT
         );
 
-        String[] actual = getStatementsFromFile(file);
+        String[] actual = getStatementsFromFile(sqlFile);
         assertArrayEquals(actual, EXPECTED_STATEMENTS);
     }
 
     @Test
     public void givenSQLFileWithBlockComments_whenParse_thenIgnoreComments() throws IOException {
-        SQLFile file = givenSQLFileWhenParse(
+        SQLFile sqlFile = givenSQLFileWhenParse(
                 STATEMENT_CREATE_TABLE + NEW_LINE + BLOCK_COMMENT + NEW_LINE + STATEMENT_ALTER_TABLE
         );
 
-        String[] actual = getStatementsFromFile(file);
+        String[] actual = getStatementsFromFile(sqlFile);
         assertArrayEquals(actual, EXPECTED_STATEMENTS);
     }
 
     @Test
     public void givenSQLFileWithLineCommentsWithinStatement_whenParse_thenIgnoreComments() throws IOException {
-        SQLFile file = givenSQLFileWhenParse(
+        SQLFile sqlFile = givenSQLFileWhenParse(
                 STATEMENT_FOR_COMMENTS_WITHIN_TESTS_1 + NEW_LINE + LINE_COMMENT + NEW_LINE + STATEMENT_FOR_COMMENTS_WITHIN_TESTS_2
         );
 
-        String[] actual = getStatementsFromFile(file);
+        String[] actual = getStatementsFromFile(sqlFile);
         assertEquals(actual.length, 1);
         assertEquals(actual[0], STATEMENT_FOR_COMMENTS_WITHIN_TESTS_1 + SPACE + STATEMENT_FOR_COMMENTS_WITHIN_TESTS_2);
     }
 
     @Test
     public void givenSQLFileWithBlockCommentsWithinStatement_whenParse_thenIgnoreComments() throws IOException {
-        SQLFile file = givenSQLFileWhenParse(
+        SQLFile sqlFile = givenSQLFileWhenParse(
                 STATEMENT_FOR_COMMENTS_WITHIN_TESTS_1 + NEW_LINE + BLOCK_COMMENT + NEW_LINE + STATEMENT_FOR_COMMENTS_WITHIN_TESTS_2
         );
 
-        String[] actual = getStatementsFromFile(file);
+        String[] actual = getStatementsFromFile(sqlFile);
         assertEquals(actual.length, 1);
         assertEquals(actual[0], STATEMENT_FOR_COMMENTS_WITHIN_TESTS_1 + SPACE + STATEMENT_FOR_COMMENTS_WITHIN_TESTS_2);
     }
@@ -84,8 +84,8 @@ public class SQLFileTest {
         return sqlFile;
     }
 
-    private String[] getStatementsFromFile(SQLFile file) {
-        List<String> statements = file.getStatements();
+    private String[] getStatementsFromFile(SQLFile sqlFile) {
+        List<String> statements = sqlFile.getStatements();
         return statements.toArray(new String[statements.size()]);
     }
 }


### PR DESCRIPTION
#### Problem

`SQLFile` handles a good part of the library behaviour, collecting all the statements needed to build the in-memory database. That database is later needed to generate the access Java classes.

If SQL files are incorrectly parsed, the generated classes won't match.

#### Solution

This PR adds the `SQLFileTest` spec, defining all of the handled use cases:

- middle case, two statements separated by a new line char
- edge case, two statements surrounded by spaces
- edge case, two statements separated by line comments
- edge case, two statements separated by block comments
- edge case, a statement with line comments in it
- edge case, a statement with block comments in it

##### Test(s) added 

Duh

##### Screenshots

NOPE

###### Paired with 

/foreveralone