### PR TITLE
Parse SQLFiles with ANTLR grammar

### DIFF
--- a/analyzer/README.md
+++ b/analyzer/README.md
@@ -1,0 +1,14 @@
+## sqlite-analyzer Gradle plugin source 
+
+This project builds the sqlite-analyzer Gradle plugin.
+
+### Note
+
+This is an independent Gradle project. It is not part of the parent directory's multi-project build.
+
+It is linked into the parent's demos via the `settings.gradle` in the parent's 
+`buildSrc` project. This way, changes in the source code are picked up immediately
+when re-running the parent's build, but still the parent project  and the plugin 
+project can run on different Gradle and Java versions.
+ 
+ 

--- a/analyzer/build.gradle
+++ b/analyzer/build.gradle
@@ -42,7 +42,7 @@ sourceSets {
 }
 
 generateGrammarSource {
-    outputDirectory = new File('src/main/build/com/novoda/sqlite/grammar')
+    outputDirectory = new File('analyzer/src/main/build/com/novoda/sqlite/grammar')
 }
 
 publish {

--- a/analyzer/build.gradle
+++ b/analyzer/build.gradle
@@ -15,6 +15,7 @@ apply plugin: 'java'
 apply plugin: 'groovy'
 apply plugin: 'bintray-release'
 apply plugin: 'com.gradle.plugin-publish'
+apply plugin: 'antlr'
 
 repositories {
     mavenCentral()
@@ -22,6 +23,7 @@ repositories {
 
 dependencies {
     compile 'org.xerial:sqlite-jdbc:3.8.7'
+    antlr 'org.antlr:antlr4:4.5.3'
 
     compile gradleApi()
     compile localGroovy()
@@ -34,6 +36,14 @@ version = '0.3.2'
 
 sourceCompatibility = JavaVersion.VERSION_1_6
 targetCompatibility = JavaVersion.VERSION_1_6
+
+sourceSets {
+    main.java.srcDir 'src/main/build'
+}
+
+generateGrammarSource {
+    outputDirectory = new File('src/main/build/com/novoda/sqlite/grammar')
+}
 
 publish {
     userOrg = 'novoda'

--- a/analyzer/build.gradle
+++ b/analyzer/build.gradle
@@ -37,14 +37,6 @@ version = '0.3.2'
 sourceCompatibility = JavaVersion.VERSION_1_6
 targetCompatibility = JavaVersion.VERSION_1_6
 
-sourceSets {
-    main.java.srcDir 'src/main/build'
-}
-
-generateGrammarSource {
-    outputDirectory = new File('src/main/build/com/novoda/sqlite/grammar')
-}
-
 publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'

--- a/analyzer/build.gradle
+++ b/analyzer/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.novoda:bintray-release:0.2.4'
+        classpath 'com.novoda:bintray-release:0.3.5'
         classpath 'com.gradle.publish:plugin-publish-plugin:0.9.0'
     }
 }
@@ -42,7 +42,7 @@ sourceSets {
 }
 
 generateGrammarSource {
-    outputDirectory = new File('analyzer/src/main/build/com/novoda/sqlite/grammar')
+    outputDirectory = new File('src/main/build/com/novoda/sqlite/grammar')
 }
 
 publish {

--- a/analyzer/src/main/antlr/com/novoda/sqlite/grammar/SQLite.g4
+++ b/analyzer/src/main/antlr/com/novoda/sqlite/grammar/SQLite.g4
@@ -1,0 +1,919 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 by Bart Kiers
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Project      : sqlite-parser; an ANTLR4 grammar for SQLite
+ *                https://github.com/bkiers/sqlite-parser
+ * Developed by : Bart Kiers, bart@big-o.nl
+ */
+grammar SQLite;
+
+@header {
+    package com.novoda.sqlite.grammar;
+}
+
+parse
+ : ( sql_stmt_list | error )* EOF
+ ;
+
+error
+ : UNEXPECTED_CHAR
+   {
+     throw new RuntimeException("UNEXPECTED_CHAR=" + $UNEXPECTED_CHAR.text);
+   }
+ ;
+
+sql_stmt_list
+ : ';'* sql_stmt ( ';'+ sql_stmt )* ';'*
+ ;
+
+sql_stmt
+ : ( K_EXPLAIN ( K_QUERY K_PLAN )? )? ( alter_table_stmt
+                                      | analyze_stmt
+                                      | attach_stmt
+                                      | begin_stmt
+                                      | commit_stmt
+                                      | compound_select_stmt
+                                      | create_index_stmt
+                                      | create_table_stmt
+                                      | create_trigger_stmt
+                                      | create_view_stmt
+                                      | create_virtual_table_stmt
+                                      | delete_stmt
+                                      | delete_stmt_limited
+                                      | detach_stmt
+                                      | drop_index_stmt
+                                      | drop_table_stmt
+                                      | drop_trigger_stmt
+                                      | drop_view_stmt
+                                      | factored_select_stmt
+                                      | insert_stmt
+                                      | pragma_stmt
+                                      | reindex_stmt
+                                      | release_stmt
+                                      | rollback_stmt
+                                      | savepoint_stmt
+                                      | simple_select_stmt
+                                      | select_stmt
+                                      | update_stmt
+                                      | update_stmt_limited
+                                      | vacuum_stmt )
+ ;
+
+alter_table_stmt
+ : K_ALTER K_TABLE ( database_name '.' )? table_name
+   ( K_RENAME K_TO new_table_name
+   | K_ADD K_COLUMN? column_def
+   )
+ ;
+
+analyze_stmt
+ : K_ANALYZE ( database_name | table_or_index_name | database_name '.' table_or_index_name )?
+ ;
+
+attach_stmt
+ : K_ATTACH K_DATABASE? expr K_AS database_name
+ ;
+
+begin_stmt
+ : K_BEGIN ( K_DEFERRED | K_IMMEDIATE | K_EXCLUSIVE )? ( K_TRANSACTION transaction_name? )?
+ ;
+
+commit_stmt
+ : ( K_COMMIT | K_END ) ( K_TRANSACTION transaction_name? )?
+ ;
+
+compound_select_stmt
+ : ( K_WITH K_RECURSIVE? common_table_expression ( ',' common_table_expression )* )?
+   select_core ( ( K_UNION K_ALL? | K_INTERSECT | K_EXCEPT ) select_core )+
+   ( K_ORDER K_BY ordering_term ( ',' ordering_term )* )?
+   ( K_LIMIT expr ( ( K_OFFSET | ',' ) expr )? )?
+ ;
+
+create_index_stmt
+ : K_CREATE K_UNIQUE? K_INDEX ( K_IF K_NOT K_EXISTS )?
+   ( database_name '.' )? index_name K_ON table_name '(' indexed_column ( ',' indexed_column )* ')'
+   ( K_WHERE expr )?
+ ;
+
+create_table_stmt
+ : K_CREATE ( K_TEMP | K_TEMPORARY )? K_TABLE ( K_IF K_NOT K_EXISTS )?
+   ( database_name '.' )? table_name
+   ( '(' column_def ( ',' column_def )*? ( ',' table_constraint )* ')' ( K_WITHOUT IDENTIFIER )?
+   | K_AS select_stmt
+   )
+ ;
+
+create_trigger_stmt
+ : K_CREATE ( K_TEMP | K_TEMPORARY )? K_TRIGGER ( K_IF K_NOT K_EXISTS )?
+   ( database_name '.' )? trigger_name ( K_BEFORE  | K_AFTER | K_INSTEAD K_OF )?
+   ( K_DELETE | K_INSERT | K_UPDATE ( K_OF column_name ( ',' column_name )* )? ) K_ON ( database_name '.' )? table_name
+   ( K_FOR K_EACH K_ROW )? ( K_WHEN expr )?
+   K_BEGIN ( ( update_stmt | insert_stmt | delete_stmt | select_stmt ) ';' )+ K_END
+ ;
+
+create_view_stmt
+ : K_CREATE ( K_TEMP | K_TEMPORARY )? K_VIEW ( K_IF K_NOT K_EXISTS )?
+   ( database_name '.' )? view_name K_AS select_stmt
+ ;
+
+create_virtual_table_stmt
+ : K_CREATE K_VIRTUAL K_TABLE ( K_IF K_NOT K_EXISTS )?
+   ( database_name '.' )? table_name
+   K_USING module_name ( '(' module_argument ( ',' module_argument )* ')' )?
+ ;
+
+delete_stmt
+ : with_clause? K_DELETE K_FROM qualified_table_name
+   ( K_WHERE expr )?
+ ;
+
+delete_stmt_limited
+ : with_clause? K_DELETE K_FROM qualified_table_name
+   ( K_WHERE expr )?
+   ( ( K_ORDER K_BY ordering_term ( ',' ordering_term )* )?
+     K_LIMIT expr ( ( K_OFFSET | ',' ) expr )?
+   )?
+ ;
+
+detach_stmt
+ : K_DETACH K_DATABASE? database_name
+ ;
+
+drop_index_stmt
+ : K_DROP K_INDEX ( K_IF K_EXISTS )? ( database_name '.' )? index_name
+ ;
+
+drop_table_stmt
+ : K_DROP K_TABLE ( K_IF K_EXISTS )? ( database_name '.' )? table_name
+ ;
+
+drop_trigger_stmt
+ : K_DROP K_TRIGGER ( K_IF K_EXISTS )? ( database_name '.' )? trigger_name
+ ;
+
+drop_view_stmt
+ : K_DROP K_VIEW ( K_IF K_EXISTS )? ( database_name '.' )? view_name
+ ;
+
+factored_select_stmt
+ : ( K_WITH K_RECURSIVE? common_table_expression ( ',' common_table_expression )* )?
+   select_core ( compound_operator select_core )*
+   ( K_ORDER K_BY ordering_term ( ',' ordering_term )* )?
+   ( K_LIMIT expr ( ( K_OFFSET | ',' ) expr )? )?
+ ;
+
+insert_stmt
+ : with_clause? ( K_INSERT
+                | K_REPLACE
+                | K_INSERT K_OR K_REPLACE
+                | K_INSERT K_OR K_ROLLBACK
+                | K_INSERT K_OR K_ABORT
+                | K_INSERT K_OR K_FAIL
+                | K_INSERT K_OR K_IGNORE ) K_INTO
+   ( database_name '.' )? table_name ( '(' column_name ( ',' column_name )* ')' )?
+   ( K_VALUES '(' expr ( ',' expr )* ')' ( ',' '(' expr ( ',' expr )* ')' )*
+   | select_stmt
+   | K_DEFAULT K_VALUES
+   )
+ ;
+
+pragma_stmt
+ : K_PRAGMA ( database_name '.' )? pragma_name ( '=' pragma_value
+                                               | '(' pragma_value ')' )?
+ ;
+
+reindex_stmt
+ : K_REINDEX ( collation_name
+             | ( database_name '.' )? ( table_name | index_name )
+             )?
+ ;
+
+release_stmt
+ : K_RELEASE K_SAVEPOINT? savepoint_name
+ ;
+
+rollback_stmt
+ : K_ROLLBACK ( K_TRANSACTION transaction_name? )? ( K_TO K_SAVEPOINT? savepoint_name )?
+ ;
+
+savepoint_stmt
+ : K_SAVEPOINT savepoint_name
+ ;
+
+simple_select_stmt
+ : ( K_WITH K_RECURSIVE? common_table_expression ( ',' common_table_expression )* )?
+   select_core ( K_ORDER K_BY ordering_term ( ',' ordering_term )* )?
+   ( K_LIMIT expr ( ( K_OFFSET | ',' ) expr )? )?
+ ;
+
+select_stmt
+ : ( K_WITH K_RECURSIVE? common_table_expression ( ',' common_table_expression )* )?
+   select_or_values ( compound_operator select_or_values )*
+   ( K_ORDER K_BY ordering_term ( ',' ordering_term )* )?
+   ( K_LIMIT expr ( ( K_OFFSET | ',' ) expr )? )?
+ ;
+
+select_or_values
+ : K_SELECT ( K_DISTINCT | K_ALL )? result_column ( ',' result_column )*
+   ( K_FROM ( table_or_subquery ( ',' table_or_subquery )* | join_clause ) )?
+   ( K_WHERE expr )?
+   ( K_GROUP K_BY expr ( ',' expr )* ( K_HAVING expr )? )?
+ | K_VALUES '(' expr ( ',' expr )* ')' ( ',' '(' expr ( ',' expr )* ')' )*
+ ;
+
+update_stmt
+ : with_clause? K_UPDATE ( K_OR K_ROLLBACK
+                         | K_OR K_ABORT
+                         | K_OR K_REPLACE
+                         | K_OR K_FAIL
+                         | K_OR K_IGNORE )? qualified_table_name
+   K_SET column_name '=' expr ( ',' column_name '=' expr )* ( K_WHERE expr )?
+ ;
+
+update_stmt_limited
+ : with_clause? K_UPDATE ( K_OR K_ROLLBACK
+                         | K_OR K_ABORT
+                         | K_OR K_REPLACE
+                         | K_OR K_FAIL
+                         | K_OR K_IGNORE )? qualified_table_name
+   K_SET column_name '=' expr ( ',' column_name '=' expr )* ( K_WHERE expr )?
+   ( ( K_ORDER K_BY ordering_term ( ',' ordering_term )* )?
+     K_LIMIT expr ( ( K_OFFSET | ',' ) expr )?
+   )?
+ ;
+
+vacuum_stmt
+ : K_VACUUM
+ ;
+
+column_def
+ : column_name type_name? column_constraint*
+ ;
+
+type_name
+ : name+? ( '(' signed_number ')'
+         | '(' signed_number ',' signed_number ')' )?
+ ;
+
+column_constraint
+ : ( K_CONSTRAINT name )?
+   ( K_PRIMARY K_KEY ( K_ASC | K_DESC )? conflict_clause K_AUTOINCREMENT?
+   | K_NOT? K_NULL conflict_clause
+   | K_UNIQUE conflict_clause
+   | K_CHECK '(' expr ')'
+   | K_DEFAULT (signed_number | literal_value | '(' expr ')')
+   | K_COLLATE collation_name
+   | foreign_key_clause
+   )
+ ;
+
+conflict_clause
+ : ( K_ON K_CONFLICT ( K_ROLLBACK
+                     | K_ABORT
+                     | K_FAIL
+                     | K_IGNORE
+                     | K_REPLACE
+                     )
+   )?
+ ;
+
+/*
+    SQLite understands the following binary operators, in order from highest to
+    lowest precedence:
+
+    ||
+    *    /    %
+    +    -
+    <<   >>   &    |
+    <    <=   >    >=
+    =    ==   !=   <>   IS   IS NOT   IN   LIKE   GLOB   MATCH   REGEXP
+    AND
+    OR
+*/
+expr
+ : literal_value
+ | BIND_PARAMETER
+ | ( ( database_name '.' )? table_name '.' )? column_name
+ | unary_operator expr
+ | expr '||' expr
+ | expr ( '*' | '/' | '%' ) expr
+ | expr ( '+' | '-' ) expr
+ | expr ( '<<' | '>>' | '&' | '|' ) expr
+ | expr ( '<' | '<=' | '>' | '>=' ) expr
+ | expr ( '=' | '==' | '!=' | '<>' ) expr
+ | expr K_AND expr
+ | expr K_OR expr
+ | function_name '(' ( K_DISTINCT? expr ( ',' expr )* | '*' )? ')'
+ | '(' expr ')'
+ | K_CAST '(' expr K_AS type_name ')'
+ | expr K_COLLATE collation_name
+ | expr K_NOT? ( K_LIKE | K_GLOB | K_REGEXP | K_MATCH ) expr ( K_ESCAPE expr )?
+ | expr ( K_ISNULL | K_NOTNULL | K_NOT K_NULL )
+ | expr K_IS K_NOT? expr
+ | expr K_NOT? K_BETWEEN expr K_AND expr
+ | expr K_NOT? K_IN ( '(' ( select_stmt
+                          | expr ( ',' expr )*
+                          )?
+                      ')'
+                    | ( database_name '.' )? table_name )
+ | ( ( K_NOT )? K_EXISTS )? '(' select_stmt ')'
+ | K_CASE expr? ( K_WHEN expr K_THEN expr )+ ( K_ELSE expr )? K_END
+ | raise_function
+ ;
+
+foreign_key_clause
+ : K_REFERENCES foreign_table ( '(' column_name ( ',' column_name )* ')' )?
+   ( ( K_ON ( K_DELETE | K_UPDATE ) ( K_SET K_NULL
+                                    | K_SET K_DEFAULT
+                                    | K_CASCADE
+                                    | K_RESTRICT
+                                    | K_NO K_ACTION )
+     | K_MATCH name
+     )
+   )*
+   ( K_NOT? K_DEFERRABLE ( K_INITIALLY K_DEFERRED | K_INITIALLY K_IMMEDIATE )? )?
+ ;
+
+raise_function
+ : K_RAISE '(' ( K_IGNORE
+               | ( K_ROLLBACK | K_ABORT | K_FAIL ) ',' error_message )
+           ')'
+ ;
+
+indexed_column
+ : column_name ( K_COLLATE collation_name )? ( K_ASC | K_DESC )?
+ ;
+
+table_constraint
+ : ( K_CONSTRAINT name )?
+   ( ( K_PRIMARY K_KEY | K_UNIQUE ) '(' indexed_column ( ',' indexed_column )* ')' conflict_clause
+   | K_CHECK '(' expr ')'
+   | K_FOREIGN K_KEY '(' column_name ( ',' column_name )* ')' foreign_key_clause
+   )
+ ;
+
+with_clause
+ : K_WITH K_RECURSIVE? cte_table_name K_AS '(' select_stmt ')' ( ',' cte_table_name K_AS '(' select_stmt ')' )*
+ ;
+
+qualified_table_name
+ : ( database_name '.' )? table_name ( K_INDEXED K_BY index_name
+                                     | K_NOT K_INDEXED )?
+ ;
+
+ordering_term
+ : expr ( K_COLLATE collation_name )? ( K_ASC | K_DESC )?
+ ;
+
+pragma_value
+ : signed_number
+ | name
+ | STRING_LITERAL
+ ;
+
+common_table_expression
+ : table_name ( '(' column_name ( ',' column_name )* ')' )? K_AS '(' select_stmt ')'
+ ;
+
+result_column
+ : '*'
+ | table_name '.' '*'
+ | expr ( K_AS? column_alias )?
+ ;
+
+table_or_subquery
+ : ( schema_name '.' )? table_name ( K_AS? table_alias )?
+   ( K_INDEXED K_BY index_name
+   | K_NOT K_INDEXED )?
+ | ( schema_name '.' )? table_function_name '(' ( expr ( ',' expr )* )? ')' ( K_AS? table_alias )?
+ | '(' ( table_or_subquery ( ',' table_or_subquery )*
+       | join_clause )
+   ')'
+ | '(' select_stmt ')' ( K_AS? table_alias )?
+ ;
+
+join_clause
+ : table_or_subquery ( join_operator table_or_subquery join_constraint )*
+ ;
+
+join_operator
+ : ','
+ | K_NATURAL? ( K_LEFT K_OUTER? | K_INNER | K_CROSS )? K_JOIN
+ ;
+
+join_constraint
+ : ( K_ON expr
+   | K_USING '(' column_name ( ',' column_name )* ')' )?
+ ;
+
+select_core
+ : K_SELECT ( K_DISTINCT | K_ALL )? result_column ( ',' result_column )*
+   ( K_FROM ( table_or_subquery ( ',' table_or_subquery )* | join_clause ) )?
+   ( K_WHERE expr )?
+   ( K_GROUP K_BY expr ( ',' expr )* ( K_HAVING expr )? )?
+ | K_VALUES '(' expr ( ',' expr )* ')' ( ',' '(' expr ( ',' expr )* ')' )*
+ ;
+
+compound_operator
+ : K_UNION
+ | K_UNION K_ALL
+ | K_INTERSECT
+ | K_EXCEPT
+ ;
+
+cte_table_name
+ : table_name ( '(' column_name ( ',' column_name )* ')' )?
+ ;
+
+signed_number
+ : ( '+' | '-' )? NUMERIC_LITERAL
+ ;
+
+literal_value
+ : NUMERIC_LITERAL
+ | STRING_LITERAL
+ | BLOB_LITERAL
+ | K_NULL
+ | K_CURRENT_TIME
+ | K_CURRENT_DATE
+ | K_CURRENT_TIMESTAMP
+ ;
+
+unary_operator
+ : '-'
+ | '+'
+ | '~'
+ | K_NOT
+ ;
+
+error_message
+ : STRING_LITERAL
+ ;
+
+module_argument // TODO check what exactly is permitted here
+ : expr
+ | column_def
+ ;
+
+column_alias
+ : IDENTIFIER
+ | STRING_LITERAL
+ ;
+
+keyword
+ : K_ABORT
+ | K_ACTION
+ | K_ADD
+ | K_AFTER
+ | K_ALL
+ | K_ALTER
+ | K_ANALYZE
+ | K_AND
+ | K_AS
+ | K_ASC
+ | K_ATTACH
+ | K_AUTOINCREMENT
+ | K_BEFORE
+ | K_BEGIN
+ | K_BETWEEN
+ | K_BY
+ | K_CASCADE
+ | K_CASE
+ | K_CAST
+ | K_CHECK
+ | K_COLLATE
+ | K_COLUMN
+ | K_COMMIT
+ | K_CONFLICT
+ | K_CONSTRAINT
+ | K_CREATE
+ | K_CROSS
+ | K_CURRENT_DATE
+ | K_CURRENT_TIME
+ | K_CURRENT_TIMESTAMP
+ | K_DATABASE
+ | K_DEFAULT
+ | K_DEFERRABLE
+ | K_DEFERRED
+ | K_DELETE
+ | K_DESC
+ | K_DETACH
+ | K_DISTINCT
+ | K_DROP
+ | K_EACH
+ | K_ELSE
+ | K_END
+ | K_ESCAPE
+ | K_EXCEPT
+ | K_EXCLUSIVE
+ | K_EXISTS
+ | K_EXPLAIN
+ | K_FAIL
+ | K_FOR
+ | K_FOREIGN
+ | K_FROM
+ | K_FULL
+ | K_GLOB
+ | K_GROUP
+ | K_HAVING
+ | K_IF
+ | K_IGNORE
+ | K_IMMEDIATE
+ | K_IN
+ | K_INDEX
+ | K_INDEXED
+ | K_INITIALLY
+ | K_INNER
+ | K_INSERT
+ | K_INSTEAD
+ | K_INTERSECT
+ | K_INTO
+ | K_IS
+ | K_ISNULL
+ | K_JOIN
+ | K_KEY
+ | K_LEFT
+ | K_LIKE
+ | K_LIMIT
+ | K_MATCH
+ | K_NATURAL
+ | K_NO
+ | K_NOT
+ | K_NOTNULL
+ | K_NULL
+ | K_OF
+ | K_OFFSET
+ | K_ON
+ | K_OR
+ | K_ORDER
+ | K_OUTER
+ | K_PLAN
+ | K_PRAGMA
+ | K_PRIMARY
+ | K_QUERY
+ | K_RAISE
+ | K_RECURSIVE
+ | K_REFERENCES
+ | K_REGEXP
+ | K_REINDEX
+ | K_RELEASE
+ | K_RENAME
+ | K_REPLACE
+ | K_RESTRICT
+ | K_RIGHT
+ | K_ROLLBACK
+ | K_ROW
+ | K_SAVEPOINT
+ | K_SELECT
+ | K_SET
+ | K_TABLE
+ | K_TEMP
+ | K_TEMPORARY
+ | K_THEN
+ | K_TO
+ | K_TRANSACTION
+ | K_TRIGGER
+ | K_UNION
+ | K_UNIQUE
+ | K_UPDATE
+ | K_USING
+ | K_VACUUM
+ | K_VALUES
+ | K_VIEW
+ | K_VIRTUAL
+ | K_WHEN
+ | K_WHERE
+ | K_WITH
+ | K_WITHOUT
+ ;
+
+// TODO check all names below
+
+name
+ : any_name
+ ;
+
+function_name
+ : any_name
+ ;
+
+database_name
+ : any_name
+ ;
+
+schema_name
+ : any_name
+ ;
+
+table_function_name
+ : any_name
+ ;
+
+table_name
+ : any_name
+ ;
+
+table_or_index_name
+ : any_name
+ ;
+
+new_table_name
+ : any_name
+ ;
+
+column_name
+ : any_name
+ ;
+
+collation_name
+ : any_name
+ ;
+
+foreign_table
+ : any_name
+ ;
+
+index_name
+ : any_name
+ ;
+
+trigger_name
+ : any_name
+ ;
+
+view_name
+ : any_name
+ ;
+
+module_name
+ : any_name
+ ;
+
+pragma_name
+ : any_name
+ ;
+
+savepoint_name
+ : any_name
+ ;
+
+table_alias
+ : IDENTIFIER
+ | STRING_LITERAL
+ | '(' table_alias ')'
+ ;
+
+transaction_name
+ : any_name
+ ;
+
+any_name
+ : IDENTIFIER
+ | keyword
+ | STRING_LITERAL
+ | '(' any_name ')'
+ ;
+
+SCOL : ';';
+DOT : '.';
+OPEN_PAR : '(';
+CLOSE_PAR : ')';
+COMMA : ',';
+ASSIGN : '=';
+STAR : '*';
+PLUS : '+';
+MINUS : '-';
+TILDE : '~';
+PIPE2 : '||';
+DIV : '/';
+MOD : '%';
+LT2 : '<<';
+GT2 : '>>';
+AMP : '&';
+PIPE : '|';
+LT : '<';
+LT_EQ : '<=';
+GT : '>';
+GT_EQ : '>=';
+EQ : '==';
+NOT_EQ1 : '!=';
+NOT_EQ2 : '<>';
+
+// http://www.sqlite.org/lang_keywords.html
+K_ABORT : A B O R T;
+K_ACTION : A C T I O N;
+K_ADD : A D D;
+K_AFTER : A F T E R;
+K_ALL : A L L;
+K_ALTER : A L T E R;
+K_ANALYZE : A N A L Y Z E;
+K_AND : A N D;
+K_AS : A S;
+K_ASC : A S C;
+K_ATTACH : A T T A C H;
+K_AUTOINCREMENT : A U T O I N C R E M E N T;
+K_BEFORE : B E F O R E;
+K_BEGIN : B E G I N;
+K_BETWEEN : B E T W E E N;
+K_BY : B Y;
+K_CASCADE : C A S C A D E;
+K_CASE : C A S E;
+K_CAST : C A S T;
+K_CHECK : C H E C K;
+K_COLLATE : C O L L A T E;
+K_COLUMN : C O L U M N;
+K_COMMIT : C O M M I T;
+K_CONFLICT : C O N F L I C T;
+K_CONSTRAINT : C O N S T R A I N T;
+K_CREATE : C R E A T E;
+K_CROSS : C R O S S;
+K_CURRENT_DATE : C U R R E N T '_' D A T E;
+K_CURRENT_TIME : C U R R E N T '_' T I M E;
+K_CURRENT_TIMESTAMP : C U R R E N T '_' T I M E S T A M P;
+K_DATABASE : D A T A B A S E;
+K_DEFAULT : D E F A U L T;
+K_DEFERRABLE : D E F E R R A B L E;
+K_DEFERRED : D E F E R R E D;
+K_DELETE : D E L E T E;
+K_DESC : D E S C;
+K_DETACH : D E T A C H;
+K_DISTINCT : D I S T I N C T;
+K_DROP : D R O P;
+K_EACH : E A C H;
+K_ELSE : E L S E;
+K_END : E N D;
+K_ESCAPE : E S C A P E;
+K_EXCEPT : E X C E P T;
+K_EXCLUSIVE : E X C L U S I V E;
+K_EXISTS : E X I S T S;
+K_EXPLAIN : E X P L A I N;
+K_FAIL : F A I L;
+K_FOR : F O R;
+K_FOREIGN : F O R E I G N;
+K_FROM : F R O M;
+K_FULL : F U L L;
+K_GLOB : G L O B;
+K_GROUP : G R O U P;
+K_HAVING : H A V I N G;
+K_IF : I F;
+K_IGNORE : I G N O R E;
+K_IMMEDIATE : I M M E D I A T E;
+K_IN : I N;
+K_INDEX : I N D E X;
+K_INDEXED : I N D E X E D;
+K_INITIALLY : I N I T I A L L Y;
+K_INNER : I N N E R;
+K_INSERT : I N S E R T;
+K_INSTEAD : I N S T E A D;
+K_INTERSECT : I N T E R S E C T;
+K_INTO : I N T O;
+K_IS : I S;
+K_ISNULL : I S N U L L;
+K_JOIN : J O I N;
+K_KEY : K E Y;
+K_LEFT : L E F T;
+K_LIKE : L I K E;
+K_LIMIT : L I M I T;
+K_MATCH : M A T C H;
+K_NATURAL : N A T U R A L;
+K_NO : N O;
+K_NOT : N O T;
+K_NOTNULL : N O T N U L L;
+K_NULL : N U L L;
+K_OF : O F;
+K_OFFSET : O F F S E T;
+K_ON : O N;
+K_OR : O R;
+K_ORDER : O R D E R;
+K_OUTER : O U T E R;
+K_PLAN : P L A N;
+K_PRAGMA : P R A G M A;
+K_PRIMARY : P R I M A R Y;
+K_QUERY : Q U E R Y;
+K_RAISE : R A I S E;
+K_RECURSIVE : R E C U R S I V E;
+K_REFERENCES : R E F E R E N C E S;
+K_REGEXP : R E G E X P;
+K_REINDEX : R E I N D E X;
+K_RELEASE : R E L E A S E;
+K_RENAME : R E N A M E;
+K_REPLACE : R E P L A C E;
+K_RESTRICT : R E S T R I C T;
+K_RIGHT : R I G H T;
+K_ROLLBACK : R O L L B A C K;
+K_ROW : R O W;
+K_SAVEPOINT : S A V E P O I N T;
+K_SELECT : S E L E C T;
+K_SET : S E T;
+K_TABLE : T A B L E;
+K_TEMP : T E M P;
+K_TEMPORARY : T E M P O R A R Y;
+K_THEN : T H E N;
+K_TO : T O;
+K_TRANSACTION : T R A N S A C T I O N;
+K_TRIGGER : T R I G G E R;
+K_UNION : U N I O N;
+K_UNIQUE : U N I Q U E;
+K_UPDATE : U P D A T E;
+K_USING : U S I N G;
+K_VACUUM : V A C U U M;
+K_VALUES : V A L U E S;
+K_VIEW : V I E W;
+K_VIRTUAL : V I R T U A L;
+K_WHEN : W H E N;
+K_WHERE : W H E R E;
+K_WITH : W I T H;
+K_WITHOUT : W I T H O U T;
+
+IDENTIFIER
+ : '"' (~'"' | '""')* '"'
+ | '`' (~'`' | '``')* '`'
+ | '[' ~']'* ']'
+ | [a-zA-Z_] [a-zA-Z_0-9]* // TODO check: needs more chars in set
+ ;
+
+NUMERIC_LITERAL
+ : DIGIT+ ( '.' DIGIT* )? ( E [-+]? DIGIT+ )?
+ | '.' DIGIT+ ( E [-+]? DIGIT+ )?
+ ;
+
+BIND_PARAMETER
+ : '?' DIGIT*
+ | [:@$] IDENTIFIER
+ ;
+
+STRING_LITERAL
+ : '\'' ( ~'\'' | '\'\'' )* '\''
+ ;
+
+BLOB_LITERAL
+ : X STRING_LITERAL
+ ;
+
+SINGLE_LINE_COMMENT
+ : '--' ~[\r\n]* -> channel(HIDDEN)
+ ;
+
+MULTILINE_COMMENT
+ : '/*' .*? ( '*/' | EOF ) -> channel(HIDDEN)
+ ;
+
+SPACES
+ : [ \u000B\t\r\n] -> channel(HIDDEN)
+ ;
+
+UNEXPECTED_CHAR
+ : .
+ ;
+
+fragment DIGIT : [0-9];
+
+fragment A : [aA];
+fragment B : [bB];
+fragment C : [cC];
+fragment D : [dD];
+fragment E : [eE];
+fragment F : [fF];
+fragment G : [gG];
+fragment H : [hH];
+fragment I : [iI];
+fragment J : [jJ];
+fragment K : [kK];
+fragment L : [lL];
+fragment M : [mM];
+fragment N : [nN];
+fragment O : [oO];
+fragment P : [pP];
+fragment Q : [qQ];
+fragment R : [rR];
+fragment S : [sS];
+fragment T : [tT];
+fragment U : [uU];
+fragment V : [vV];
+fragment W : [wW];
+fragment X : [xX];
+fragment Y : [yY];
+fragment Z : [zZ];

--- a/analyzer/src/main/java/com/novoda/sqlite/MigrationsConnector.java
+++ b/analyzer/src/main/java/com/novoda/sqlite/MigrationsConnector.java
@@ -37,8 +37,7 @@ public class MigrationsConnector implements Connector {
         Statement statement = connection.createStatement();
         for (File migration : migrations) {
             try {
-                List<String> statements = null;
-                statements = SQLFile.statementsFrom(migration);
+                List<String> statements = SQLFile.statementsFrom(migration);
                 for (String sqlCommand : statements) {
                     statement.executeUpdate(sqlCommand);
                 }

--- a/analyzer/src/main/java/com/novoda/sqlite/impl/SQLFile.java
+++ b/analyzer/src/main/java/com/novoda/sqlite/impl/SQLFile.java
@@ -38,9 +38,7 @@ public class SQLFile {
 
         this.statements = new ArrayList<String>(statementList.size());
         for (SQLiteParser.Sql_stmtContext statement : statementList) {
-            int startIndex = statement.getStart().getStartIndex();
-            int stopIndex = statement.getStop().getStopIndex();
-            String textStatement = sqlContent.substring(startIndex, stopIndex + 1) + ";";
+            String textStatement = getStringFromStatement(sqlContent, statement);
             this.statements.add(textStatement);
         }
     }
@@ -56,6 +54,12 @@ public class SQLFile {
         bufferedReader.close();
 
         return stringBuilder.toString();
+    }
+
+    private String getStringFromStatement(String sqlContent, SQLiteParser.Sql_stmtContext statement) {
+        int startIndex = statement.getStart().getStartIndex();
+        int stopIndex = statement.getStop().getStopIndex();
+        return sqlContent.substring(startIndex, stopIndex + 1) + ";";
     }
 
     public List<String> getStatements() {

--- a/analyzer/src/main/java/com/novoda/sqlite/impl/SQLFile.java
+++ b/analyzer/src/main/java/com/novoda/sqlite/impl/SQLFile.java
@@ -19,9 +19,6 @@ import org.antlr.v4.runtime.CommonTokenStream;
  */
 public class SQLFile {
 
-    private static final String NEW_LINE = "\n";
-    private static final String SEMICOLON = ";";
-
     private List<String> statements;
 
     public void parse(Reader in) throws IOException {
@@ -43,7 +40,7 @@ public class SQLFile {
         for (SQLiteParser.Sql_stmtContext statement : statementList) {
             int startIndex = statement.getStart().getStartIndex();
             int stopIndex = statement.getStop().getStopIndex();
-            String textStatement = sqlContent.substring(startIndex, stopIndex + 1) + SEMICOLON;
+            String textStatement = sqlContent.substring(startIndex, stopIndex + 1) + ";";
             this.statements.add(textStatement);
         }
     }
@@ -54,7 +51,7 @@ public class SQLFile {
 
         BufferedReader bufferedReader = new BufferedReader(reader);
         while ((line = bufferedReader.readLine()) != null) {
-            stringBuilder.append(line).append(NEW_LINE);
+            stringBuilder.append(line).append("\n");
         }
         bufferedReader.close();
 

--- a/analyzer/src/main/java/com/novoda/sqlite/impl/SQLFile.java
+++ b/analyzer/src/main/java/com/novoda/sqlite/impl/SQLFile.java
@@ -29,10 +29,18 @@ public class SQLFile {
 
         SQLiteLexer lexer = new SQLiteLexer(new ANTLRInputStream(sqlContent));
         SQLiteParser parser = new SQLiteParser(new CommonTokenStream(lexer));
-        List<SQLiteParser.Sql_stmtContext> statementListContext = parser.parse().sql_stmt_list(0).sql_stmt();
 
-        this.statements = new ArrayList<String>(statementListContext.size());
-        for (SQLiteParser.Sql_stmtContext statement : statementListContext) {
+        // parse() contains a list of sql_stmt_list
+        List<SQLiteParser.Sql_stmt_listContext> statementListContext = parser.parse().sql_stmt_list();
+
+        // every sql_stmt_list contains one or more sql_stmt, we need to flatten it
+        List<SQLiteParser.Sql_stmtContext> statementList = new ArrayList<SQLiteParser.Sql_stmtContext>();
+        for (SQLiteParser.Sql_stmt_listContext statements : statementListContext) {
+            statementList.addAll(statements.sql_stmt());
+        }
+
+        this.statements = new ArrayList<String>(statementList.size());
+        for (SQLiteParser.Sql_stmtContext statement : statementList) {
             int startIndex = statement.getStart().getStartIndex();
             int stopIndex = statement.getStop().getStopIndex();
             String textStatement = sqlContent.substring(startIndex, stopIndex + 1) + SEMICOLON;

--- a/analyzer/src/test/java/com/novoda/sqlite/impl/SQLFileTest.java
+++ b/analyzer/src/test/java/com/novoda/sqlite/impl/SQLFileTest.java
@@ -77,7 +77,7 @@ public class SQLFileTest {
     }
 
     @Test
-    public void givenSqlFileWithTable_andTableWithDoubleDashes_whenParse_thenDoNotTreatDashesAsComment() throws IOException {
+    public void givenSQLFileWithTable_andTableWithDoubleDashes_whenParse_thenDoNotTreatDashesAsComment() throws IOException {
         String sqlContent = "CREATE TABLE `all--pizzas`(flavor TEXT);";
         SQLFile sqlFile = givenSQLFileWhenParse(sqlContent);
 

--- a/analyzer/src/test/java/com/novoda/sqlite/impl/SQLFileTest.java
+++ b/analyzer/src/test/java/com/novoda/sqlite/impl/SQLFileTest.java
@@ -25,7 +25,7 @@ public class SQLFileTest {
         SQLFile sqlFile = givenSQLFileWhenParse(STATEMENT_CREATE_TABLE + NEW_LINE + STATEMENT_ALTER_TABLE);
 
         String[] actual = getStatementsFromFile(sqlFile);
-        assertArrayEquals(actual, EXPECTED_STATEMENTS);
+        assertArrayEquals(EXPECTED_STATEMENTS, actual);
     }
 
     @Test
@@ -33,7 +33,7 @@ public class SQLFileTest {
         SQLFile sqlFile = givenSQLFileWhenParse(SPACE + STATEMENT_CREATE_TABLE + SPACE + NEW_LINE + SPACE + STATEMENT_ALTER_TABLE + SPACE);
 
         String[] actual = getStatementsFromFile(sqlFile);
-        assertArrayEquals(actual, EXPECTED_STATEMENTS);
+        assertArrayEquals(EXPECTED_STATEMENTS, actual);
     }
 
     @Test
@@ -43,7 +43,7 @@ public class SQLFileTest {
         );
 
         String[] actual = getStatementsFromFile(sqlFile);
-        assertArrayEquals(actual, EXPECTED_STATEMENTS);
+        assertArrayEquals(EXPECTED_STATEMENTS, actual);
     }
 
     @Test
@@ -53,29 +53,37 @@ public class SQLFileTest {
         );
 
         String[] actual = getStatementsFromFile(sqlFile);
-        assertArrayEquals(actual, EXPECTED_STATEMENTS);
+        assertArrayEquals(EXPECTED_STATEMENTS, actual);
     }
 
     @Test
-    public void givenSQLFileWithLineCommentsWithinStatement_whenParse_thenIgnoreComments() throws IOException {
-        SQLFile sqlFile = givenSQLFileWhenParse(
-                STATEMENT_FOR_COMMENTS_WITHIN_TESTS_1 + NEW_LINE + LINE_COMMENT + NEW_LINE + STATEMENT_FOR_COMMENTS_WITHIN_TESTS_2
-        );
+    public void givenSQLFileWithLineCommentsWithinStatement_whenParse_thenLeaveCommentsInStatement() throws IOException {
+        String sqlContent = STATEMENT_FOR_COMMENTS_WITHIN_TESTS_1 + NEW_LINE + LINE_COMMENT + NEW_LINE + STATEMENT_FOR_COMMENTS_WITHIN_TESTS_2;
+        SQLFile sqlFile = givenSQLFileWhenParse(sqlContent);
 
         String[] actual = getStatementsFromFile(sqlFile);
         assertEquals(actual.length, 1);
-        assertEquals(actual[0], STATEMENT_FOR_COMMENTS_WITHIN_TESTS_1 + SPACE + STATEMENT_FOR_COMMENTS_WITHIN_TESTS_2);
+        assertEquals(sqlContent, actual[0]);
     }
 
     @Test
-    public void givenSQLFileWithBlockCommentsWithinStatement_whenParse_thenIgnoreComments() throws IOException {
-        SQLFile sqlFile = givenSQLFileWhenParse(
-                STATEMENT_FOR_COMMENTS_WITHIN_TESTS_1 + NEW_LINE + BLOCK_COMMENT + NEW_LINE + STATEMENT_FOR_COMMENTS_WITHIN_TESTS_2
-        );
+    public void givenSQLFileWithBlockCommentsWithinStatement_whenParse_thenLeaveCommentsInStatement() throws IOException {
+        String sqlContent = STATEMENT_FOR_COMMENTS_WITHIN_TESTS_1 + NEW_LINE + BLOCK_COMMENT + NEW_LINE + STATEMENT_FOR_COMMENTS_WITHIN_TESTS_2;
+        SQLFile sqlFile = givenSQLFileWhenParse(sqlContent);
 
         String[] actual = getStatementsFromFile(sqlFile);
         assertEquals(actual.length, 1);
-        assertEquals(actual[0], STATEMENT_FOR_COMMENTS_WITHIN_TESTS_1 + SPACE + STATEMENT_FOR_COMMENTS_WITHIN_TESTS_2);
+        assertEquals(sqlContent, actual[0]);
+    }
+
+    @Test
+    public void givenSqlFileWithTable_andTableWithDoubleDashes_whenParse_thenDoNotTreatDashesAsComment() throws IOException {
+        String sqlContent = "CREATE TABLE `all--pizzas`(flavor TEXT);";
+        SQLFile sqlFile = givenSQLFileWhenParse(sqlContent);
+
+        String[] actual = getStatementsFromFile(sqlFile);
+        assertEquals(actual.length, 1);
+        assertEquals(sqlContent, actual[0]);
     }
 
     private SQLFile givenSQLFileWhenParse(String sql) throws IOException {

--- a/analyzer/src/test/java/com/novoda/sqlite/impl/SQLFileTest.java
+++ b/analyzer/src/test/java/com/novoda/sqlite/impl/SQLFileTest.java
@@ -86,6 +86,15 @@ public class SQLFileTest {
         assertEquals(sqlContent, actual[0]);
     }
 
+    @Test
+    public void givenSQLFileWithMultipleStatementsInOneLine_whenParse_thenGetTwoStatements() throws IOException {
+        String sqlContent = "CREATE TABLE `one`(id INTEGER); CREATE TABLE `two`(id INTEGER);";
+        SQLFile sqlFile = givenSQLFileWhenParse(sqlContent);
+
+        String[] actual = getStatementsFromFile(sqlFile);
+        assertEquals(actual.length, 2);
+    }
+
     private SQLFile givenSQLFileWhenParse(String sql) throws IOException {
         SQLFile sqlFile = new SQLFile();
         sqlFile.parse(new StringReader(sql));

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
         classpath 'com.novoda:gradle-android-command-plugin:1.3.0'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.android.tools.build:gradle:2.0.0'
         classpath 'com.novoda:gradle-android-command-plugin:1.3.0'
     }
 }
@@ -22,6 +22,6 @@ allprojects {
 }
 
 ext {
-    BUILD_TOOLS_VERSION = '21.1.2'
+    BUILD_TOOLS_VERSION = '23.0.3'
     COMPILE_SDK_VERSION = 21
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,3 @@
-include 'demo-assethelper', 'demo-sqliteprovider'
-
+include 'demo-assethelper'
+include 'demo-sqliteprovider'
+include 'analyzer'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,2 @@
 include 'demo-assethelper'
 include 'demo-sqliteprovider'
-include 'analyzer'


### PR DESCRIPTION
#### Problem

`SQLFile` parses the input statements manually, without relying on a proper state machine nor grammar definition. Therefore, it may discard syntactically valid statements such as:

```sql
CREATE TABLE `all--pizzas`(id INTEGER);
```

since it naively assumes that everything that comes after `--` is a line comment'.

Furthermore, it doesn't acknowledge multiple statements unless they are separated by a new line:

```sql
CREATE TABLE `one`(id INTEGER); CREATE TABLE `two`(id INTEGER);
```

#### Solution

This PR uses a SQLite grammar definition for ANTLR4 to address these issues (and potentially many more).

The initial grammar definition is, [per SQLite reference](https://www.sqlite.org/lang.html):

```
sql_stmt_list : sql_stmt (';' sql_stmt )* ';'
```

`SQLFile#parse` now accesses the parsing tree, then moves to `sql_stmt_list`, looping on all the contained `sql_stmt`.

The grammar lexer will also be leveraged in an upcoming PR for the `TableCreateStatementParser`.

##### Test(s) added 

Changed tests:

- do not remove line comments
- do not remove block comments

New tests:

- do not remove double dashes everywhere, they may be part of the statement as they aren't always a comment
- make sure that multiple statements on a single line are correctly returned separately

###### Paired with 

Noam Chomsky