### PR TITLE
remove unneeded customization, add README

### DIFF
--- a/analyzer/README.md
+++ b/analyzer/README.md
@@ -1,0 +1,14 @@
+## sqlite-analyzer Gradle plugin source 
+
+This project builds the sqlite-analyzer Gradle plugin.
+
+### Note
+
+This is an independent Gradle project. It is not part of the parent directory's multi-project build.
+
+It is linked into the parent's demos via the `settings.gradle` in the parent's 
+`buildSrc` project. This way, changes in the source code are picked up immediately
+when re-running the parent's build, but still the parent project  and the plugin 
+project can run on different Gradle and Java versions.
+ 
+ 

--- a/analyzer/build.gradle
+++ b/analyzer/build.gradle
@@ -37,14 +37,6 @@ version = '0.3.2'
 sourceCompatibility = JavaVersion.VERSION_1_6
 targetCompatibility = JavaVersion.VERSION_1_6
 
-sourceSets {
-    main.java.srcDir 'src/main/build'
-}
-
-generateGrammarSource {
-    outputDirectory = new File('src/main/build/com/novoda/sqlite/grammar')
-}
-
 publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,2 @@
 include 'demo-assethelper'
 include 'demo-sqliteprovider'
-include 'analyzer'


### PR DESCRIPTION
This should still be running the antlr code generation and compilation.

Also, adds a README to the actual Gradle plugin project, explaining why it is not part of its parent's build.
